### PR TITLE
Allow option field values to be ojects

### DIFF
--- a/_testdata/releaseVersion.proto
+++ b/_testdata/releaseVersion.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+service CoreAPIContracts {
+    option (api.section) = "Contrats";
+    option (release.service) = {
+        change_type: ADD_SERVICE
+        feature_flag: "KERN_220_NEW_SIMULATION_API_DEFINITIONS"
+        release_version: {major: 1, minor: 12}
+    };
+    // A dummy RPC that will soon be replaced by a real one.
+    rpc DummyRPC(DummyRPCRequest) returns (DummyRPCResponse) {
+        option (google.api.http) = {
+            get: "/v1/contracts-dummy"
+        };
+    };
+}

--- a/_testdata/releaseVersion.proto
+++ b/_testdata/releaseVersion.proto
@@ -1,16 +1,16 @@
 syntax = "proto3";
 
-service CoreAPIContracts {
-    option (api.section) = "Contrats";
+service ExampleService {
+    option (api.section) = "Test";
     option (release.service) = {
-        change_type: ADD_SERVICE
-        feature_flag: "KERN_220_NEW_SIMULATION_API_DEFINITIONS"
-        release_version: {major: 1, minor: 12}
+        option1: value1
+        option2: "Value 2"
+        option3: {x1: 1, x2: 12}
     };
-    // A dummy RPC that will soon be replaced by a real one.
+
     rpc DummyRPC(DummyRPCRequest) returns (DummyRPCResponse) {
         option (google.api.http) = {
-            get: "/v1/contracts-dummy"
+            get: "/endpoint/value"
         };
     };
 }

--- a/parser/option.go
+++ b/parser/option.go
@@ -139,11 +139,22 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (*CloudEndpoint, error) {
 			if p.lex.Token != scanner.TCOLON {
 				return nil, p.unexpected(":")
 			}
-
-			constant, _, err := p.lex.ReadConstant(p.permissive)
-			if err != nil {
-				return nil, err
+			
+			constant := ""
+			if p.lex.Peek() == scanner.TLEFTCURLY {
+				endpoint, err := p.parseCloudEndpointsOptionConstant()
+				if err != nil {
+					return nil, err
+				}
+				constant = OptionConstantToString(endpoint)
+			} else {
+				cons, _, err := p.lex.ReadConstant(p.permissive)
+				if err != nil {
+					return nil, err
+				}
+				constant = cons
 			}
+
 			endpointFields = append(endpointFields, &EndpointFieldOption{
 				OptionName: ident,
 				Constant:   constant,
@@ -163,6 +174,15 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (*CloudEndpoint, error) {
 			p.lex.UnNext()
 		}
 	}
+}
+
+func OptionConstantToString(endpoint *CloudEndpoint) (string) {
+ 	result := "{"
+	for _, field := range endpoint.Fields {
+		result += field.OptionName + ":" + field.Constant + ","
+	}
+	result += "}"
+	return result
 }
 
 // optionName = ( ident | "(" fullIdent ")" ) { "." ident }

--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -276,6 +276,45 @@ option (google.api.http) = {
 				},
 			},
 		},
+		{
+			name: "parse option field object values",
+			input: `
+option (release.service) = {
+        release_version: {major: 1, minor: 12}
+};`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "(release.service)",
+				Constant:   "",
+				Endpoint: &parser.CloudEndpoint{
+					Fields: []*parser.EndpointFieldOption{
+						{
+							OptionName: "release_version",
+							Constant:   "{major:1,minor:12,}",
+							Meta: meta.Meta{
+								Pos: meta.Position{
+									Offset: 38,
+									Line:   3,
+									Column: 9,
+								},
+							},
+						},
+					},
+				},
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 78,
+						Line:   4,
+						Column: 2,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/protoparser_test.go
+++ b/protoparser_test.go
@@ -40,3 +40,15 @@ func TestParseReservedEnumFile(t *testing.T) {
 		t.Errorf("Failed to parse proto, %v", err)
 	}
 }
+
+func TestParseReleaseVersionFile(t *testing.T) {
+	reader, err := os.Open("_testdata/releaseVersion.proto")
+	if err != nil {
+		t.Error("Failed to open file")
+	}
+	defer reader.Close()
+	_, err = Parse(reader)
+	if err != nil {
+		t.Errorf("Failed to parse proto, %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds the ability for the go-protoparser to parse objects as field values. This will directly allow the addition of release versions to be added to protos. This has been achieved by adding a recursive case to the function responsible for parsing option fields values, this will allow many nested objects.

__Testing__
I have included tests in this PR to test this new functionality. I test that the file which previously crashed the parser now passes. I also test that a parsed option field with object values appears as expected.